### PR TITLE
Add abacusutils to package list

### DIFF
--- a/cosmodesimodules/pkg_list.txt
+++ b/cosmodesimodules/pkg_list.txt
@@ -4,4 +4,4 @@ pyrecon @ https://github.com/cosmodesi/pyrecon @ branches/main,1.0.0
 pycorr @ https://github.com/cosmodesi/pycorr @ branches/main,1.0.0
 Corrfunc @ https://github.com/adematti/Corrfunc @ branches/desi,desi-1.0.0
 pypower @ https://github.com/cosmodesi/pypower @ branches/main,1.0.0
-abacusutils https://github.com/abacusorg/abacusutils @ branches/main
+abacusutils @ https://github.com/abacusorg/abacusutils @ branches/main

--- a/cosmodesimodules/pkg_list.txt
+++ b/cosmodesimodules/pkg_list.txt
@@ -4,3 +4,4 @@ pyrecon @ https://github.com/cosmodesi/pyrecon @ branches/main,1.0.0
 pycorr @ https://github.com/cosmodesi/pycorr @ branches/main,1.0.0
 Corrfunc @ https://github.com/adematti/Corrfunc @ branches/desi,desi-1.0.0
 pypower @ https://github.com/cosmodesi/pypower @ branches/main,1.0.0
+abacusutils https://github.com/abacusorg/abacusutils @ branches/main


### PR DESCRIPTION
Hi @adematti, we've reduced the primary dependency footprint in https://github.com/abacusorg/abacusutils/pull/46, so I think abacusutils is ready to be tested in cosmodesiconda.  I haven't released a new version on pip with the changes, so I haven't added a tag/version number to `pkg_list.txt` yet.  Are we able to test it like this, and then we can add a version number once we're finished testing and I make the release?

x-ref: #1